### PR TITLE
Fix typos in Sphinx docs

### DIFF
--- a/docs/sphinx_doc/4hammer.md
+++ b/docs/sphinx_doc/4hammer.md
@@ -912,7 +912,7 @@ func on_state_changed():
 		quad.visible = false
     # for all actions that can be taken
 	for action in GlobalRules.valid_actions:
-		var unwrapped = action.unwrap() # the the raw valid action
+                var unwrapped = action.unwrap() # the raw valid action
 		if unwrapped.members_count() != 1: # if has not exactly one argument we don't know what the semantics are, we will ignore it.
 			continue
 		if not unwrapped.get_member(0) is RLCBoardPosition: # if the only argument is not a RLCBoardPosition we don't know the semantics
@@ -941,22 +941,22 @@ act move(ctx Board board, ctx UnitID unit, frm StatModifier additional_movement)
     ...
 ```
 
-Without knowing anything related to the UI, the user declared a `move_to` action, never referenced by any godot specific code. Since it accepts a `BoardPosion`, it is auto detected by the UI code.
+Without knowing anything related to the UI, the user declared a `move_to` action, never referenced by any Godot-specific code. Since it accepts a `BoardPosition`, it is auto detected by the UI code.
 
-Of course, this is very inefficient. In practice it does not matter since the objective of 4hammer is not to draw billions of polygons on screen, but it one wished to make it more efficient it could have enumerated all possible types of valid actions instead of introspecting actions at run time, and then checked if those particular actions where valid.
+Of course, this is very inefficient. In practice it does not matter since the objective of 4hammer is not to draw billions of polygons on screen, but if one wished to make it more efficient it could have enumerated all possible types of valid actions instead of introspecting actions at run time, and then checked if those particular actions were valid.
 
-A even more efficient, but less flexible implementation would have been to to directly invoke a call back from RLC code yielding the most optimal implementation, but that would require some extra trickery to make sure machine learning stuff still works.
+An even more efficient, but less flexible implementation would have been to directly invoke a callback from RLC code yielding the most optimal implementation, but that would require some extra trickery to make sure machine learning stuff still works.
 
 ### Supported autoconfigurations
 * all actions that accepts a single BoardPosition are interpreted as the user being allowed to click on the board.
-* all actions that accept a UnitID are interpred as the user wishing to click on a unit. All valid units glow and can be clicked.
-* all actions taht accept a ModelID display the model glowing and allow the user to click on it. The rule writer must specify which unit that model belongs to, to be able to tell them apart.
-* all actions that accepts 2 UnitID are interpretd as the user wishing to make interact the first unit with the second unit. For example shooting with a unit onto another. The UI allows to drag a arrow from the start unit torward the target unit.
-* actions that accept a single bool display to the user the name of the action phraased as a question.
-* actions that accept a enum display the valid choises on screen for the player to select.
+* all actions that accept a UnitID are interpreted as the user wishing to click on a unit. All valid units glow and can be clicked.
+* all actions that accept a ModelID display the model glowing and allow the user to click on it. The rule writer must specify which unit that model belongs to, to be able to tell them apart.
+* all actions that accept 2 UnitID are interpreted as the user wishing to make the first unit interact with the second unit. For example shooting with a unit onto another. The UI allows you to drag an arrow from the start unit toward the target unit.
+* actions that accept a single bool display to the user the name of the action phrased as a question.
+* actions that accept an enum display the valid choices on screen for the player to select.
 
 ## Remote execution
-Since the entirety of the game rules are writte into Rulebook action functions, we obtain for free remote execution. [Here](https://github.com/rl-language/4Hammer/blob/master/scripts/server.gd#L1) is the trivial implementation of the server component on the side of godot, that waits for connections that then issue server commands. Some special server commands are handle nativelly by godot, such as exfiltrating the current image on screen and send it over network or stopping the rendering of the screen entirelly.
+Since the entirety of the game rules are written into Rulebook action functions, we obtain for free remote execution. [Here](https://github.com/rl-language/4Hammer/blob/master/scripts/server.gd#L1) is the trivial implementation of the server component on the side of Godot, that waits for connections that then issue server commands. Some special server commands are handled natively by Godot, such as exfiltrating the current image on screen and sending it over the network or stopping the rendering of the screen entirely.
 
 Every other action is simply a rulebook action implied by the rules of the game. Every time a rule programmer changes one of those rules, the remote execution mechanism updates itself automatically. Furthermore, since the network is issuing commands exactly like in process graphical elements are, the only thing that cannot be tested over network is the act on interacting on ui elements themselves.
 

--- a/docs/sphinx_doc/interoperating.md
+++ b/docs/sphinx_doc/interoperating.md
@@ -151,9 +151,9 @@ rlc /tmp/file.rl -o /tmp/exec /tmp/lib.a
 
 ## Interop with CPP
 
-The interop with cpp is identical to the one with C, except the generated header detects cpp is available so it will remove the need for manual managment of constructors and destructors.
+The interop with cpp is identical to the one with C, except the generated header detects cpp is available so it will remove the need for manual management of constructors and destructors.
 
-Let us revisig the previous example in cpp.
+Let us revisit the previous example in cpp.
 
 ```rlc
 # file.rl
@@ -310,11 +310,11 @@ Our large example [4Hammer](./4hammer.md) shows interop with godot and cmake.
 
 ## Interop with unreal
 
-Unfortunatelly there is no way for a unreal engine plugin to hook inside the the build system of unreal. We have no way to package Rulebook in a way that can be hot reloaded from Unreal without the unreal programmer providing some code themselves. For unreal you have to start from the CPP interop and build from there.
+Unfortunately there is no way for an Unreal engine plugin to hook into the build system of Unreal. We have no way to package Rulebook in a way that can be hot reloaded from Unreal without the Unreal programmer providing some code themselves. For Unreal you have to start from the CPP interop and build from there.
 
 ## CMake
 
-We expose typical actions one my wish to perform from cmake as a cmake config file. This includes correct managment of imported files in rulebook for incremental builds, the various wrappers generators and so on. You can see examples in the [godot plugin cmake file](https://github.com/rl-language/4Hammer/blob/master/CMakeLists.txt) of 4hammer.
+We expose typical actions one may wish to perform from CMake as a CMake config file. This includes correct management of imported files in Rulebook for incremental builds, the various wrapper generators and so on. You can see examples in the [godot plugin CMake file](https://github.com/rl-language/4Hammer/blob/master/CMakeLists.txt) of 4hammer.
 
 ## Cross compiling
 

--- a/docs/sphinx_doc/rlc.md
+++ b/docs/sphinx_doc/rlc.md
@@ -184,7 +184,7 @@ This program is only available in a pip installation.
 
 ## rlc-learn
 
-rlc-learn uses a off-the-shelf implmentation of PPO to maximize some metric in a given Rulebook program. This tool is intended to be used to perform sanity checks by those that wish to roll out their own machine learning algorithm, or by those that do not have knowledge of reinforcement learning and wish to use a acceptable off-the-shelf implementation. A basic tutorial is shown [here](./tutorial.md).
+rlc-learn uses an off-the-shelf implementation of PPO to maximize some metric in a given Rulebook program. This tool is intended to be used to perform sanity checks by those that wish to roll out their own machine learning algorithm, or by those that do not have knowledge of reinforcement learning and wish to use an acceptable off-the-shelf implementation. A basic tutorial is shown [here](./tutorial.md).
 
 The command accepts a number of options controlling how the program is
 compiled and how the training loop behaves.  All options from

--- a/docs/sphinx_doc/stdlib/collections/graph.md
+++ b/docs/sphinx_doc/stdlib/collections/graph.md
@@ -18,8 +18,8 @@
 - **Function**: `add_edge(Node<NodeLabel, EdgeLabel> other, EdgeLabel label) `
 - **Function**: `get_outgoing(Int index)  -> ref Edge<EdgeLabel>`
 - **Function**: `get_size_outgoing()  -> Int`
-- **Function**: `get_size_incomming()  -> Int`
-- **Function**: `get_incomming(Int index)  -> Int`
+- **Function**: `get_size_incoming()  -> Int`
+- **Function**: `get_incoming(Int index)  -> Int`
 - **Function**: `get_label()  -> ref NodeLabel`
 - **Function**: `get_id()  -> Int`
 
@@ -32,7 +32,7 @@
 - **Function**: `add_node() `
 - **Function**: `remove_edge(Node<NodeLabel, EdgeLabel> node, Int edge_id) `
 - **Function**: `erase_outgoing_edges(Node<NodeLabel, EdgeLabel> n) `
-- **Function**: `erase_incomming_edges(Node<NodeLabel, EdgeLabel> n) `
+- **Function**: `erase_incoming_edges(Node<NodeLabel, EdgeLabel> n) `
 - **Function**: `remove_node(Node<NodeLabel, EdgeLabel> n) `
 - **Function**: `get_node(Int node_id)  -> ref Node<NodeLabel, EdgeLabel>`
 - **Function**: `get_nodes_size()  -> Int`

--- a/docs/sphinx_doc/stdlib/string.md
+++ b/docs/sphinx_doc/stdlib/string.md
@@ -50,7 +50,7 @@
 - **Function**: `count(Byte b)  -> Int`
 
 ```text
- returns the number of occurences
+ returns the number of occurrences
  a certain character appears in the string
 
 ```

--- a/docs/sphinx_doc/tutorial.md
+++ b/docs/sphinx_doc/tutorial.md
@@ -1,6 +1,6 @@
 # Tutorial for RL people
 
-The `Rulebook` language is designed, among other things, to help you use reinforcement learning techniques. It does so by helping you write simulated environments in which machine learning agents can learn, without requiring the user to write any code related to machine learning, beside specificing minimal and maximal bounds of variables.
+The `Rulebook` language is designed, among other things, to help you use reinforcement learning techniques. It does so by helping you write simulated environments in which machine learning agents can learn, without requiring the user to write any code related to machine learning, beside specifying minimal and maximal bounds of variables.
 
 The `RL` language does not provide new reinforcement learning methods; instead, it concerns itself with the issue of writing simulations only. You can use any learning algorithm you wish when using an `RL` language simulation.
 


### PR DESCRIPTION
## Summary
- correct typos in tutorial and reference docs
- fix wording in interoperability guide
- clean up 4Hammer example documentation
- fix spelling in stdlib docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684360bb9ac48333bb1b762069751c9e