### PR TITLE
Fix typos in docs

### DIFF
--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -48,13 +48,13 @@ Since design principles are themselves designed, we should have a general rule f
 ##### Interoperability
 The problem we are trying to solve is that reusing code written for a given engine in another context is hard. This implies that interoperability is the whole point of what we are trying to do. RL must be a simple-to-integrate language, ideally as simple as integrating C.
 
-##### Indipendence from the underlying machine
+##### Independence from the underlying machine
 The abstract machine of the language should not talk in terms of the underlying machine, because that will make porting programs that rely on a specific machine's behavior hard, defeating the whole point of the language.
 
 ##### Speed
 We cannot know who will use this language, we cannot make an if statement run slower than it runs in C, if we do, people will sometimes need to go back to C to achieve the performance required.
 
-##### Memory indipendence
+##### Memory independence
  We should not make assumptions on anything related to memory other than the existence of malloc. The code emitted should not introduce more malloc invocations than it would be done by writing the code in C.
 
 ##### Composability

--- a/docs/rationale.md
+++ b/docs/rationale.md
@@ -115,7 +115,7 @@ Indeed, this is the case for most projects trying to solve this issue:
 * The [Game Description Language](https://en.wikipedia.org/wiki/Game_Description_Language) also distinguishes `legal moves`, `update rules`, and `termination`.
 * Games with millions of copies sold, such as [CK2](https://ck2.paradoxwikis.com/Ze_Lunatic_(Conclave)) have their own custom language where they can express `events` that are composed of `trigger conditions` that must be satisfied before they can manifest, `decisions` the player can select and `effects` that are applied if that `decision` is taken, and `flags` used to coordinate different events.
 
-We live in a world where billion dollar companies write code for custom hardware accellerators in Python and then turn around and implement TicTacToe in C.
+We live in a world where billion dollar companies write code for custom hardware accelerators in Python and then turn around and implement TicTacToe in C.
 
 The four properties identified before, `inspectability`, `serializability`, `precondition checkability`, and `no main loop ownership` generate this pattern discovered again and again by different programmers in different contexts. Simulations and games that exist in the mind of developers as normal-looking programs end up rewritten in such a way that those four properties are respected, by explicating the underlying control flow diagram that describes them.
 
@@ -200,7 +200,7 @@ class TicTacToe:
       self.resumption_index = -1 # -1 means we reached the end of the function
 
   def can_mark(self, x: int, y: int) -> Bool:
-    # implied by `act mark` being rechable from the entry point of `play()`
+    # implied by `act mark` being reachable from the entry point of `play()`
     if self.resumption_index != 0:
       return False
 
@@ -228,7 +228,7 @@ class TicTacToe:
    return self.resumption_index == 1
 ```
 
-This is it, the whole Raison d'etre of the `rl` language is just that, to automatize the tedious and error-prone process of translating a procedure-like description of a simulation into a class-like description.
+This is it, the whole raison d'être of the `rl` language is just that, to automate the tedious and error-prone process of translating a procedure-like description of a simulation into a class-like description.
 
 ## Building on top of it
 We saw that `rl` has been created to solve the 4 issues of `inspectability`, `serializability`, `precondition checkability`, and `no main loop ownership` described earlier.  Of course, having a tool able to perform this transformation is not the end of the story. Since that simple implementation `TicTacToe` describes in a compact way
@@ -240,7 +240,7 @@ then instrumentation can be written to generically exploit one or more of these 
 * generate the wrapper for the simulation in different languages and for different frameworks (C, CPP, C# and Python currently supported)
 * generate fuzzers that try random valid moves and look for bugs.
 * generate the network layer that allows to remotely interact with the simulation [example here](https://github.com/rl-language/4Hammer/blob/master/examples/engine_driver.py).
-* statically prove that some actions can never be executed and thus the code is not right, just like unrechable code.
+* statically prove that some actions can never be executed and thus the code is not right, just like unreachable code.
 * automatically serialize and deserialize the state of the simulation.
 
 ###  Conclusion

--- a/docs/space_hulk_level_design.md
+++ b/docs/space_hulk_level_design.md
@@ -122,7 +122,7 @@ To recap, Space Hulk is a game of average complexity that has difficult properti
 
 ## RL implementation
 
-[This](../tool/rlc/test/examples/space_hulk/) folder contains the implementation of Space Hulk used for the training. The most significant file is the [main.rl](../tool/rlc/test/examples/space_hulk/main.rl) file. Ignoring test functions, the whole implementation of space hulk ammounts to ~1000 lines of code.
+[This](../tool/rlc/test/examples/space_hulk/) folder contains the implementation of Space Hulk used for the training. The most significant file is the [main.rl](../tool/rlc/test/examples/space_hulk/main.rl) file. Ignoring test functions, the whole implementation of space hulk amounts to ~1000 lines of code.
 Of course since space hulk is a real game and not just a proof of concept, the files are not trivial to read.
 
 There are two points we want to put under the spotlight:
@@ -143,7 +143,7 @@ The action toggle door takes as argument the id of the unit that is trying to to
 
 This piece of code is the entire implementation of toggling a door in the game. By writing this piece of code the machine learning components are automatically aware that this is something they can do. You do not need to specify anything else.
 
-If you remove that block of code, the possibility of removing a door will disapear from existance and the machine learning will no longer be allowed to toggle them.
+If you remove that block of code, the possibility of removing a door will disappear from existence and the machine learning will no longer be allowed to toggle them.
 
 Look now at the shoot action:
 
@@ -168,7 +168,7 @@ The shoot action specifies that it needs two argument, the ID of the source and 
 
 * Notice as well that while the game contains some obscure keywords that are specific to this language, the files contain no code that is specific to machine learning. Every line of code is expressing game concepts, and is doing so in a imperative manner. If you can understand the previous two illustrated functions, you can edit them and you can replicate the results presented in this document.
 
-If you want a more in depth tutorial to create a RL file for your game, you can read more here [Tutorial comming soon!].
+If you want a more in depth tutorial to create a RL file for your game, you can read more here [Tutorial coming soon!].
 If you are interested in the theoretical side of how we achieve our results, you can read more [here](./rationale.md), and you can see easier examples which have both entry points at the function called play() [here](../tool/rlc/test/tic_tac_toe.rl ) and [here](../tool/rlc/test/pebble_game.rl)
 
 

--- a/docs/sphinx_doc/4hammer.md
+++ b/docs/sphinx_doc/4hammer.md
@@ -721,7 +721,7 @@ class RerrolableRoll {
         is_non_cp_rerollable(is_non_cp_rerollable),
         current_player(current_player) {}
     void roll(GameState& state, Dice dice) {
-        assert(can_roll(state), sate);
+        assert(can_roll(state), state);
         result = dice;
         if (suspensionPoint == 0){ // if this is the first time we roll the dice
             is_non_cp_rerollable = can_reroll or (can_reroll_1s and result == 1) // figure out if we can reroll for free
@@ -751,7 +751,7 @@ class RerrolableRoll {
     bool can_keep_it(GameState& state, Bool do_it) {
         return suspensionPoint == 1;
     }
-    struct ActionRoll { // a class that rappresents a action, in a way that can be stored and executed later
+    struct ActionRoll { // a class that rappresents an action, in a way that can be stored and executed later
         Dice roll;
         void apply(RerollableDiceRoll rollBeingResolved, GameState& state) {
            rollBeingResolved.roll(state, roll);
@@ -903,7 +903,7 @@ The rulebook libraries have been designed to expose a [finite interactive progra
 
 ## Self configuring UI
 
-One of the objective of the Rulebook is to be able to modify rules and have the UI automatically adapt to them. We achieve this using the language [action classes](./language_tour.md#action-statements-classes). Here is a example, the godot script that handles the [game board](https://github.com/rl-language/4Hammer/blob/master/scripts/boardl.gd#L22) so that whenever a action related to selecting the board is possible, the elegible locations glow yellow.
+One of the objective of the Rulebook is to be able to modify rules and have the UI automatically adapt to them. We achieve this using the language [action classes](./language_tour.md#action-statements-classes). Here is a example, the godot script that handles the [game board](https://github.com/rl-language/4Hammer/blob/master/scripts/boardl.gd#L22) so that whenever an action related to selecting the board is possible, the eligible locations glow yellow.
 
 ```godot
 # triggers after every action
@@ -912,7 +912,7 @@ func on_state_changed():
 		quad.visible = false
     # for all actions that can be taken
 	for action in GlobalRules.valid_actions:
-		var unwrapped = action.unwrap() # the the raw valid action
+                var unwrapped = action.unwrap() # the raw valid action
 		if unwrapped.members_count() != 1: # if has not exactly one argument we don't know what the semantics are, we will ignore it.
 			continue
 		if not unwrapped.get_member(0) is RLCBoardPosition: # if the only argument is not a RLCBoardPosition we don't know the semantics
@@ -924,12 +924,12 @@ func on_state_changed():
 		quads[board_position.get_x().get_value() * 100 + board_position.get_y().get_value()].visible = true
 ```
 
-The UI only can introspect valid actions, make sure that they have the expected shape of only requring a single `BoardPosition` argument, and then highlight that particular board location.
+The UI only can introspect valid actions, make sure that they have the expected shape of only requiring a single `BoardPosition` argument, and then highlight that particular board location.
 
-This meas that the rule writer can write rules such as the current implementation of moving a game piece on the board
+This means that the rule writer can write rules such as the current implementation of moving a game piece on the board
 
 ```rlc
-# core rules movement rules, including the possiblity
+# core rules movement rules, including the possibility
 # of advancing and the triggering of overwatches
 act move(ctx Board board, ctx UnitID unit, frm StatModifier additional_movement) -> Move:
     if board[unit.get()].models.size() == 0:
@@ -941,22 +941,22 @@ act move(ctx Board board, ctx UnitID unit, frm StatModifier additional_movement)
     ...
 ```
 
-Without knowing anything related to the UI, the user declared a `move_to` action, never referenced by any godot specific code. Since it accepts a `BoardPosion`, it is auto detected by the UI code.
+Without knowing anything related to the UI, the user declared a `move_to` action, never referenced by any Godot-specific code. Since it accepts a `BoardPosition`, it is auto detected by the UI code.
 
-Of course, this is very inefficient. In practice it does not matter since the objective of 4hammer is not to draw billions of polygons on screen, but it one wished to make it more efficient it could have enumerated all possible types of valid actions instead of introspecting actions at run time, and then checked if those particular actions where valid.
+Of course, this is very inefficient. In practice it does not matter since the objective of 4hammer is not to draw billions of polygons on screen, but if one wished to make it more efficient it could have enumerated all possible types of valid actions instead of introspecting actions at run time, and then checked if those particular actions were valid.
 
-A even more efficient, but less flexible implementation would have been to to directly invoke a call back from RLC code yielding the most optimal implementation, but that would require some extra trickery to make sure machine learning stuff still works.
+An even more efficient, but less flexible implementation would have been to directly invoke a callback from RLC code yielding the most optimal implementation, but that would require some extra trickery to make sure machine learning stuff still works.
 
 ### Supported autoconfigurations
 * all actions that accepts a single BoardPosition are interpreted as the user being allowed to click on the board.
-* all actions that accept a UnitID are interpred as the user wishing to click on a unit. All valid units glow and can be clicked.
-* all actions taht accept a ModelID display the model glowing and allow the user to click on it. The rule writer must specify which unit that model belongs to, to be able to tell them apart.
-* all actions that accepts 2 UnitID are interpretd as the user wishing to make interact the first unit with the second unit. For example shooting with a unit onto another. The UI allows to drag a arrow from the start unit torward the target unit.
-* actions that accept a single bool display to the user the name of the action phraased as a question.
-* actions that accept a enum display the valid choises on screen for the player to select.
+* all actions that accept a UnitID are interpreted as the user wishing to click on a unit. All valid units glow and can be clicked.
+* all actions that accept a ModelID display the model glowing and allow the user to click on it. The rule writer must specify which unit that model belongs to, to be able to tell them apart.
+* all actions that accept 2 UnitID are interpreted as the user wishing to make the first unit interact with the second unit. For example shooting with a unit onto another. The UI allows you to drag an arrow from the start unit toward the target unit.
+* actions that accept a single bool display to the user the name of the action phrased as a question.
+* actions that accept an enum display the valid choices on screen for the player to select.
 
 ## Remote execution
-Since the entirety of the game rules are writte into Rulebook action functions, we obtain for free remote execution. [Here](https://github.com/rl-language/4Hammer/blob/master/scripts/server.gd#L1) is the trivial implementation of the server component on the side of godot, that waits for connections that then issue server commands. Some special server commands are handle nativelly by godot, such as exfiltrating the current image on screen and send it over network or stopping the rendering of the screen entirelly.
+Since the entirety of the game rules are written into Rulebook action functions, we obtain for free remote execution. [Here](https://github.com/rl-language/4Hammer/blob/master/scripts/server.gd#L1) is the trivial implementation of the server component on the side of Godot, that waits for connections that then issue server commands. Some special server commands are handled natively by Godot, such as exfiltrating the current image on screen and sending it over the network or stopping the rendering of the screen entirely.
 
 Every other action is simply a rulebook action implied by the rules of the game. Every time a rule programmer changes one of those rules, the remote execution mechanism updates itself automatically. Furthermore, since the network is issuing commands exactly like in process graphical elements are, the only thing that cannot be tested over network is the act on interacting on ui elements themselves.
 

--- a/docs/sphinx_doc/board_games.md
+++ b/docs/sphinx_doc/board_games.md
@@ -7,7 +7,7 @@ This page assumes that the reader is familiar with the typical characteristics o
 
 ## The history of board game programming.
 Board games have been for a long time both of interest and of disinterest for the field of programming.
-* **Abstract board games** have been deeply analyzed for the purpose of developing traditional AI systems[[1]](https://en.wikipedia.org/wiki/Deep_Blue_(chess_computer)), [[2]](https://en.wikipedia.org/wiki/AlphaGo). Abstract board games typically include a low number of distict game rules that yield complex emergent dynamics.
+* **Abstract board games** have been deeply analyzed for the purpose of developing traditional AI systems[[1]](https://en.wikipedia.org/wiki/Deep_Blue_(chess_computer)), [[2]](https://en.wikipedia.org/wiki/AlphaGo). Abstract board games typically include a low number of distinct game rules that yield complex emergent dynamics.
 * **Commercial board games** instead have been of little interest for the field of artificial intelligence, as well as have been of low interest for the field of video game programming. **Commercial board games** often have large amounts of rules written on game components, such as **Magic: The gathering** cards, that offer to the players complex sequences of actions, while the total amount of information a game state presents is usually low, because the user must be able to keep track of it in their minds. Instead, Video games often offer large amounts information, offered to the player whenever the information is needed, while single game sequences are simpler. For example, in many games you can press any button of any interface in any order. While there exists various digital implementations of board games, for example [board game arena](https://en.boardgamearena.com), in practice the larger video game programming ecosystem is not tuned for the development of digital board games.
 
 
@@ -64,11 +64,11 @@ As of the moment of writing general board game programming often follows the sam
 * **The datastructures of the game are implemented**, such as decks of cards, the board of the game, the resources available to players...
 * **The game sequences are implemented**, which manipulate the content of the game datastructures. A game sequence may be a rule that tells you to roll a dice, and if the roll results in a 6, you can select a player and take a point from them.
 * **The UI is assembled**, deciding which game components are shown where, and deciding how game sequences are displayed.
-* **The UI is fitted with art**, where the art is usually at least partially avaiable due to the existance of the phisical board game implementation.
+* **The UI is fitted with art**, where the art is usually at least partially available due to the existence of the physical board game implementation.
 
 
 Here are a couple of examples that show the same pattern.
-* The implementation of [coup on board game arena](https://github.com/quietmint/bga-coupcitystate), which has the datastructures written in **SQL**, the game sequeces written in **PHP**, the UI written in **javascript** and the images taken from the original game.
+* The implementation of [coup on board game arena](https://github.com/quietmint/bga-coupcitystate), which has the datastructures written in **SQL**, the game sequences written in **PHP**, the UI written in **javascript** and the images taken from the original game.
 * The implementation of [hanabi by google deep mind](https://github.com/google-deepmind/hanabi-learning-environment) for the purpose of testing machine learning systems, which implements the datastructures of the game as **CPP** classes, the game sequences as **CPP** state machines, and then specifies the UI as a mere printing function.
 
 ---

--- a/docs/sphinx_doc/building.md
+++ b/docs/sphinx_doc/building.md
@@ -6,7 +6,7 @@ Building on windows is supported but at the moment undocumented.
 
 ## Downloading sources
 
-Execute line by line the content of [setup.sh](https://github.com/rl-language/rlc/blob/master/setup.sh). If you are on a "normal enough" linux or mac machine you can just download the file and execute it, but the stranger is your machine configuration the more likelly is to break.
+Execute line by line the content of [setup.sh](https://github.com/rl-language/rlc/blob/master/setup.sh). If you are on a "normal enough" linux or mac machine you can just download the file and execute it, but the stranger is your machine configuration the more likely is to break.
 
 **setup.sh** will
 * check that you have python3, ninja and cmake.
@@ -31,7 +31,7 @@ source rlc-infrastructure/rlc/environment.sh
 Beside making sure that you have the correct python virtual environment enabled, this command will make sure that when we build LLVM it is available to RLC, even without installing LLVM.
 
 ## Building
-A properly compiled RLC minimal installation depends on nothing except typical cpp libraries, but when building RLC itself we need a specific configuration of LLVM. For this reason we provide a build script that will configure the directories in a resonable configuration.
+A properly compiled RLC minimal installation depends on nothing except typical cpp libraries, but when building RLC itself we need a specific configuration of LLVM. For this reason we provide a build script that will configure the directories in a reasonable configuration.
 
 to do so, you can run
 
@@ -71,7 +71,7 @@ rlc-release
 rlc-release/install # here is the installation you care about, probably
 ```
 
-After this has compleated successfully, you can disregard build.py, use regular ninja commands
+After this has completed successfully, you can disregard build.py, use regular ninja commands
 
 ## Successive builds
 
@@ -97,7 +97,7 @@ lit --verbose tool/rlc/test --filter NAME # run end to end compiler tests
 ```
 
 ## Running the built rlc
-If you have built rlc from sources there are two ways of doing it. You can first install it, and use it from the insall directory
+If you have built rlc from sources there are two ways of doing it. You can first install it, and use it from the install directory
 ```
 cd rlc-infrastructure
 ninja all

--- a/docs/sphinx_doc/gym_tutorial.md
+++ b/docs/sphinx_doc/gym_tutorial.md
@@ -213,7 +213,7 @@ As expected, only the three actions available to player 0 are valid at the start
 
 ## Applying actions
 
-To advance the state, there is a very simple function, `step` which accepts the index of the action to execute and returns the reward of that action, measure as the different between the score before the action has been executed and the score after the action has been executed.
+To advance the state, there is a very simple function, `step` which accepts the index of the action to execute and returns the reward of that action, measured as the difference between the score before the action has been executed and the score after the action has been executed.
 ```
 with compile(["./rockpaperscizzor.rl"]) as program:
     exit_on_invalid_env(program)

--- a/docs/sphinx_doc/interoperating.md
+++ b/docs/sphinx_doc/interoperating.md
@@ -7,7 +7,7 @@ This page describes how you can connect Rulebook to other languages. It is not p
 We achieve interoperability with C almost trivially since Rulebook has the same ABI as C.
 
 ### Calling rulebook from C
-* Each Rulebook class is mapped onto a C struct. Each alternative is mapped on a struct with a union and a integer inside. You have to manually invoke the init, assign and drop method whenever you allocate, copy or destroy a rlc dastructure (unless the method is not available at all, which means that the datastruture is trivially initializable, copiable or destructible).
+* Each Rulebook class is mapped onto a C struct. Each alternative is mapped on a struct with a union and a integer inside. You have to manually invoke the init, assign and drop method whenever you allocate, copy or destroy a rlc datastructure (unless the method is not available at all, which means that the datastructure is trivially initializable, copiable or destructible).
 * Every enum is mapped on a struct with a integer inside.
 * Every Action Function frame is mapped on a struct with the frm variables and a integer inside.
 * All arguments of functions are taken by pointer, the return value is passed as first argument. The return value does not need to be initialized by the caller, but it must be destroyed by the caller.
@@ -25,12 +25,12 @@ rlc file.rl -o lib.a --compile # uses linux naming conventions
 rlc file.rl -o header.h --header
 ```
 
-Then you can use the header from C by inlcuding it, with a couple of macro definitions to specify what you want in particular from the header.
+Then you can use the header from C by including it, with a couple of macro definitions to specify what you want in particular from the header.
 ```c
 // file.c
 #include <stdint.h>
 #include <stdbool.h>
-#define RLC_GET_FUNCTION_DECLS // required or the header does not emit function delcs
+#define RLC_GET_FUNCTION_DECLS // required or the header does not emit function decls
 #define RLC_GET_TYPE_DEFS // required or the header does not emit the types.
 #include "./header.h"
 
@@ -47,7 +47,7 @@ clang file.c lib.a -o executable
 ./executable
 ```
 
-Here is a example that uses the most imporant features of rlc:
+Here is a example that uses the most important features of rlc:
 ```rlc
 # file.rl
 import collections.vector
@@ -72,7 +72,7 @@ act sequence(ctx Context context) -> Sequence:
 #include <stdbool.h>
 #include <stdint.h>
 #define RLC_GET_FUNCTION_DECLS // required or the header does not emit function
-                               // delcs
+                               // decls
 #define RLC_GET_TYPE_DECLS
 #define RLC_GET_TYPE_DEFS // required or the header does not emit the wrapper.
 #include "./header.h"
@@ -104,7 +104,7 @@ rlc /tmp/file.rl /tmp/lib.a -o /tmp/exec
 /tmp/exec # [15]
 ```
 
-This example shows most of the functinalities you may need in C, there is only one missing thing, which is how do you call C from rulebook.
+This example shows most of the functionalities you may need in C, there is only one missing thing, which is how do you call C from rulebook.
 
 ### Calling C from rulebook
 
@@ -132,7 +132,7 @@ write the c
 #include <stdbool.h>
 #include <stdint.h>
 #define RLC_GET_FUNCTION_DECLS // required or the header does not emit function
-                               // delcs
+                               // decls
 #define RLC_GET_TYPE_DECLS
 #define RLC_GET_TYPE_DEFS // required or the header does not emit the wrapper.
 #include "./header.h"
@@ -151,9 +151,9 @@ rlc /tmp/file.rl -o /tmp/exec /tmp/lib.a
 
 ## Interop with CPP
 
-The interop with cpp is identical to the one with C, except the generated header detects cpp is available so it will remove the need for manual managment of constructors and destructors.
+The interop with cpp is identical to the one with C, except the generated header detects cpp is available so it will remove the need for manual management of constructors and destructors.
 
-Let us revisig the previous example in cpp.
+Let us revisit the previous example in cpp.
 
 ```rlc
 # file.rl
@@ -179,7 +179,7 @@ act sequence(ctx Context context) -> Sequence:
 #include <stdbool.h>
 #include <stdint.h>
 #define RLC_GET_FUNCTION_DECLS // required or the header does not emit function
-                               // delcs
+                               // decls
 #define RLC_GET_TYPE_DECLS
 #define RLC_GET_TYPE_DEFS // required or the header does not emit the wrapper.
 #include "./header.h"
@@ -310,11 +310,11 @@ Our large example [4Hammer](./4hammer.md) shows interop with godot and cmake.
 
 ## Interop with unreal
 
-Unfortunatelly there is no way for a unreal engine plugin to hook inside the the build system of unreal. We have no way to package Rulebook in a way that can be hot reloaded from Unreal without the unreal programmer providing some code themselves. For unreal you have to start from the CPP interop and build from there.
+Unfortunately there is no way for an Unreal engine plugin to hook into the build system of Unreal. We have no way to package Rulebook in a way that can be hot reloaded from Unreal without the Unreal programmer providing some code themselves. For Unreal you have to start from the CPP interop and build from there.
 
 ## CMake
 
-We expose typical actions one my wish to perform from cmake as a cmake config file. This includes correct managment of imported files in rulebook for incremental builds, the various wrappers generators and so on. You can see examples in the [godot plugin cmake file](https://github.com/rl-language/4Hammer/blob/master/CMakeLists.txt) of 4hammer.
+We expose typical actions one may wish to perform from CMake as a CMake config file. This includes correct management of imported files in Rulebook for incremental builds, the various wrapper generators and so on. You can see examples in the [godot plugin CMake file](https://github.com/rl-language/4Hammer/blob/master/CMakeLists.txt) of 4hammer.
 
 ## Cross compiling
 

--- a/docs/sphinx_doc/language_tour.md
+++ b/docs/sphinx_doc/language_tour.md
@@ -3,7 +3,7 @@
 [Rulebook](https://github.com/rl-language/rlc) is a compiled and statically checked language.
 
 ```rlc
-# rlc hellow world
+# rlc hello world
 import serialization.print
 
 cls SimpleRegularCode:

--- a/docs/sphinx_doc/project_rationale.md
+++ b/docs/sphinx_doc/project_rationale.md
@@ -65,7 +65,7 @@ Rules are therefore:
 
 All of these issues impede machine learning adoption in the game programming space. In the next section, we will see what solution we propose.
 
-## Unifing games and machine learning.
+## Unifying games and machine learning.
 
 From the previous sections we have seen that the requirements imposed by machine learning and game programming are very different, let us recap them here. Game rules must be
 * **inspectable data structures**: the state of the game is of interest to the machine learning engine, so it must be inspectable, serializable, and copiable.

--- a/docs/sphinx_doc/rlc.md
+++ b/docs/sphinx_doc/rlc.md
@@ -144,7 +144,7 @@ Notice that rlc-lsp must be in PATH, so if you are using the PIP package of rule
 `vscode` has a plugin available in the plugin store called `rl-lsp` and `rl-language` that enables autocomplete and syntax highlighting.
 
 ### VIM with YouCompleteMe
-On `vim`, if you use `YouCompleteMe` you can get access to automplete by adding the followings to your .vimrc file.
+On `vim`, if you use `YouCompleteMe` you can get access to automplete by adding the following to your .vimrc file.
 
 ```
 au BufRead,BufNewFile *.rl set filetype=rl
@@ -176,7 +176,7 @@ This program is only available in a pip installation.
 
 rlc-random runs random actions on a program with a finite amount of actions, and does until it reaches the end of the program. It prints the selected actions.
 
-This tool is usefull as a command line utility to quickly test a interactive program, or to produce a trace usefull to some other program.
+This tool is useful as a command line utility to quickly test a interactive program, or to produce a trace useful to some other program.
 
 To be usable with rlc-random, a program just requires that to have a entry point with the following signature `act play() -> Game`, and that all `action statements` that appear in `play` are enumerable.
 
@@ -184,7 +184,7 @@ This program is only available in a pip installation.
 
 ## rlc-learn
 
-rlc-learn uses a off-the-shelf implmentation of PPO to maximize some metric in a given Rulebook program. This tool is intended to be used to perform sanity checks by those that wish to roll out their own machine learning algorithm, or by those that do not have knowledge of reinforcement learning and wish to use a acceptable off-the-shelf implementation. A basic tutorial is shown [here](./tutorial.md).
+rlc-learn uses an off-the-shelf implementation of PPO to maximize some metric in a given Rulebook program. This tool is intended to be used to perform sanity checks by those that wish to roll out their own machine learning algorithm, or by those that do not have knowledge of reinforcement learning and wish to use an acceptable off-the-shelf implementation. A basic tutorial is shown [here](./tutorial.md).
 
 The command accepts a number of options controlling how the program is
 compiled and how the training loop behaves.  All options from
@@ -277,7 +277,7 @@ This program is only available in a pip installation.
 
 ## rlc-action
 
-Applies a execution trace to a rulebook program, and then prints the final result. This tool is usefull to check if a trace is valid, if the traced program is correct.
+Applies a execution trace to a rulebook program, and then prints the final result. This tool is useful to check if a trace is valid, if the traced program is correct.
 
 The command accepts the standard compilation flags exposed by
 `make_rlc_argparse` together with a few options controlling how the trace is
@@ -312,7 +312,7 @@ This program is only available in a pip installation.
 
 ## Tools for compiler people
 
-This section of the document talks about the internal components of RLC, and is meant for compiler developers, not users of the language. If you are confused about what this means and you are wondering if this section is for your, it is not, altough you can still read it if you are interested in knowing what goes on under rlc hood.
+This section of the document talks about the internal components of RLC, and is meant for compiler developers, not users of the language. If you are confused about what this means and you are wondering if this section is for your, it is not, although you can still read it if you are interested in knowing what goes on under rlc hood.
 
 ## RLC internals
 
@@ -377,7 +377,7 @@ The parser is a recursive descent handwritten parser, the parser takes the token
 
 
 ### Unchecked AST
-Before typechecking the AST of the language is unchecked, it means that almost every non trivial operation is marked as having unkown type.
+Before typechecking the AST of the language is unchecked, it means that almost every non trivial operation is marked as having unknown type.
 
 You can see the token stream with `rlc --unchecked file.rl`
 
@@ -425,7 +425,7 @@ You can see the token stream with `rlc --ir file.rl` to see the LLVM ir. You can
 
 ### Making IR more readable
 
-When priting the RLC IR you can pass `--hide-positions` and `--hide-dl` to omit the module data layout and the module debug positions. That makes the IR slightly more readable.
+When printing the RLC IR you can pass `--hide-positions` and `--hide-dl` to omit the module data layout and the module debug positions. That makes the IR slightly more readable.
 
 ### MLIR
 
@@ -439,7 +439,7 @@ In practice what we get out MLIR is:
 * the textual serializers for MLIR
 * mlir-opt which runs single passes of mlir
 * some basic type interfaces
-* MLIR dataflow analisys
+* MLIR dataflow analysis
 
 ### Running single RLC passes
 

--- a/docs/sphinx_doc/stdlib/collections/graph.md
+++ b/docs/sphinx_doc/stdlib/collections/graph.md
@@ -18,8 +18,8 @@
 - **Function**: `add_edge(Node<NodeLabel, EdgeLabel> other, EdgeLabel label) `
 - **Function**: `get_outgoing(Int index)  -> ref Edge<EdgeLabel>`
 - **Function**: `get_size_outgoing()  -> Int`
-- **Function**: `get_size_incomming()  -> Int`
-- **Function**: `get_incomming(Int index)  -> Int`
+- **Function**: `get_size_incoming()  -> Int`
+- **Function**: `get_incoming(Int index)  -> Int`
 - **Function**: `get_label()  -> ref NodeLabel`
 - **Function**: `get_id()  -> Int`
 
@@ -32,7 +32,7 @@
 - **Function**: `add_node() `
 - **Function**: `remove_edge(Node<NodeLabel, EdgeLabel> node, Int edge_id) `
 - **Function**: `erase_outgoing_edges(Node<NodeLabel, EdgeLabel> n) `
-- **Function**: `erase_incomming_edges(Node<NodeLabel, EdgeLabel> n) `
+- **Function**: `erase_incoming_edges(Node<NodeLabel, EdgeLabel> n) `
 - **Function**: `remove_node(Node<NodeLabel, EdgeLabel> n) `
 - **Function**: `get_node(Int node_id)  -> ref Node<NodeLabel, EdgeLabel>`
 - **Function**: `get_nodes_size()  -> Int`

--- a/docs/sphinx_doc/stdlib/collections/vector.md
+++ b/docs/sphinx_doc/stdlib/collections/vector.md
@@ -117,8 +117,8 @@
  A bounded vector is a wrapper
  around a vector that prevents 
  the size of the vector to ever 
- exced `max_size`
- this class is usefull when used
+ exceed `max_size`
+ this class is useful when used
  for machine learning techniques, 
  since it allows the machine learning
  to know the maximal possible size
@@ -174,7 +174,7 @@
 ```text
  append `value` to the end
  of the vector, but only if
- doing so would not excede
+ doing so would not exceed
  max vector maximal size
 
 ```

--- a/docs/sphinx_doc/stdlib/machine_learning.md
+++ b/docs/sphinx_doc/stdlib/machine_learning.md
@@ -4,7 +4,7 @@
 
 
 ```text
- A Hidden object rapresents a object that is not visibile to machine
+ A Hidden object represents a object that is not visible to machine
  learning algorithms. For example a machine learning algorithms learning
  to play black jack should not have access to the deck of cards, so it can be wrapped into a hidden to achieve that effect
 

--- a/docs/sphinx_doc/stdlib/math/numeric.md
+++ b/docs/sphinx_doc/stdlib/math/numeric.md
@@ -25,7 +25,7 @@
 - **Function**: `min(Int a, Int b)  -> Int`
 
 ```text
- retursn the min between two numbers
+ returns the min between two numbers
 
 ```
 

--- a/docs/sphinx_doc/stdlib/none.md
+++ b/docs/sphinx_doc/stdlib/none.md
@@ -9,8 +9,8 @@
  See stdlib/LICENSE.TXT for license information.
  SPDX-License-Identifier: MIT
 
- A class to rapresent the absence of information
- usefull to implement functions that return optionals
+ A class to represent the absence of information
+ useful to implement functions that return optionals
  fun maybe_int() -> Int | Nothing:
 
 ```

--- a/docs/sphinx_doc/stdlib/string.md
+++ b/docs/sphinx_doc/stdlib/string.md
@@ -50,7 +50,7 @@
 - **Function**: `count(Byte b)  -> Int`
 
 ```text
- returns the number of occurences
+ returns the number of occurrences
  a certain character appears in the string
 
 ```
@@ -58,14 +58,14 @@
 - **Function**: `append(StringLiteral str) `
 
 ```text
- appens `str` to the current string
+ appends `str` to the current string
 
 ```
 
 - **Function**: `append(String str) `
 
 ```text
- appens `str` to the current string
+ appends `str` to the current string
 
 ```
 

--- a/docs/sphinx_doc/tutorial.md
+++ b/docs/sphinx_doc/tutorial.md
@@ -1,6 +1,6 @@
 # Tutorial for RL people
 
-The `Rulebook` language is designed, among other things, to help you use reinforcement learning techniques. It does so by helping you write simulated environments in which machine learning agents can learn, without requiring the user to write any code related to machine learning, beside specificing minimal and maximal bounds of variables.
+The `Rulebook` language is designed, among other things, to help you use reinforcement learning techniques. It does so by helping you write simulated environments in which machine learning agents can learn, without requiring the user to write any code related to machine learning, beside specifying minimal and maximal bounds of variables.
 
 The `RL` language does not provide new reinforcement learning methods; instead, it concerns itself with the issue of writing simulations only. You can use any learning algorithm you wish when using an `RL` language simulation.
 
@@ -62,18 +62,18 @@ After you have copied it, let us make sure we can run generate a random game.
 rlc-random black_jack.rl
 ```
 
-You will see that it prints the actions to be executed in a game, this include the shuffling of the deck.
-You can visualize what is happeing with
+You will see that it prints the actions to be executed in a game, this includes the shuffling of the deck.
+You can visualize what is happening with
 
 ```
 rlc-random black_jack.rl -o game.log
 rlc-action black_jack.rl game.log -pp
 ```
 
-You will be able to visualize the evolution of the deck while it is being suffled, and then see which action the player will take.
+You will be able to visualize the evolution of the deck while it is being shuffled, and then see which action the player will take.
 
 
-Now that we have visualized a random game, we can start learning! Tou can run `rlc-learn` to do so:
+Now that we have visualized a random game, we can start learning! You can run `rlc-learn` to do so:
 ```bash
 rlc-learn black_jack.rl |& tee log.txt
 ```
@@ -96,7 +96,7 @@ You should see a graph that looks similar to the following:
 
 ![tensorboard example](./imgs/mean_reward.png)
 
-The x-axis is the number of actions played. In the case of our game, it means the number of `hits` and `stand` executed, the y-axis is instead the average score obtained. As exepected the average score is increasing, that is: it is learning to play.
+The x-axis is the number of actions played. In the case of our game, it means the number of `hits` and `stand` executed, the y-axis is instead the average score obtained. As expected the average score is increasing, that is: it is learning to play.
 
 Of course, the machine will never achieve a average score of one, because there is no guarantee you can always hit 21 points, not even if you knew the order of the cards in the deck. Furthermore, the size of the neural network has been defaulted to a reasonable size, but there is no guarantee that the problem is solvable given the default size.
 
@@ -130,7 +130,7 @@ import random
 # load the rl file
 program = compile(["black_jack.rl"])
 # starts a rlc program invoking the user defined play
-# function and wraps it in object for with some usefull methods
+# function and wraps it in object for with some useful methods
 state = program.start()
 
 # invokes directly the user defined function on the real state object

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -156,7 +156,7 @@ You should see a graph that looks similar to the following:
 
 ![tensorboard example](../imgs/mean_reward.png)
 
-The x-axis is the number of actions played. In the case of our game, it means the number of `hits` and `stand` executed, the y-axis is instead the average score obtained. As exepected the average score is increasing, that is: it is learning to play.
+The x-axis is the number of actions played. In the case of our game, it means the number of `hits` and `stand` executed, the y-axis is instead the average score obtained. As expected the average score is increasing, that is: it is learning to play.
 
 Of course, the machine will never achieve a average score of one, because there is no guarantee you can always hit 21 points, not even if you knew the order of the cards in the deck. Furthermore, the size of the neural network has been defaulted to a reasonable size, but there is no guarantee that the problem is solvable given the default size.
 
@@ -190,7 +190,7 @@ import random
 # load the rl file
 program = compile(["black_jack.rl"])
 # starts a rlc program invoking the user defined play
-# function and wraps it in object for with some usefull methods
+# function and wraps it in object with some useful methods
 state = program.start()
 
 # invokes directly the user defined function on the real state object

--- a/docs/where_we_are_going.md
+++ b/docs/where_we_are_going.md
@@ -65,7 +65,7 @@ Rules are therefore:
 
 All of these issues impede machine learning adoption in the game programming space. In the next section, we will see what solution we propose.
 
-### Unifing games and machine learning.
+### Unifying games and machine learning.
 
 From the previous sections we have seen that the requirements imposed by machine learning and game programming are very different, let us recap them here. Game rules must be
 * **inspectable data structures**: the state of the game is of interest to the machine learning engine, so it must be inspectable, serializable, and copiable.


### PR DESCRIPTION
## Summary
- correct datastructure phrasing
- ensure macro comments mention "decls" instead of "delcs"
- validate docs with `codespell`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684360bb9ac48333bb1b762069751c9e