### PR TITLE
Fix documentation typos

### DIFF
--- a/docs/sphinx_doc/board_games.md
+++ b/docs/sphinx_doc/board_games.md
@@ -1,6 +1,6 @@
 # Board games
 
-This page describes how one can write and test board games. Using **rulebook**, one can decrease by at least a order of magnitude the code complexity of writing digital implementations of board game.
+This page describes how one can write and test board games. Using **Rulebook**, you can reduce the code complexity of digital board game implementations by at least an order of magnitude.
 This page assumes that the reader is familiar with the typical characteristics of board games, and enough knowledge of programming to be able to implement a game of the complexity of **Risk**.
 
 ---
@@ -8,7 +8,7 @@ This page assumes that the reader is familiar with the typical characteristics o
 ## The history of board game programming.
 Board games have been for a long time both of interest and of disinterest for the field of programming.
 * **Abstract board games** have been deeply analyzed for the purpose of developing traditional AI systems[[1]](https://en.wikipedia.org/wiki/Deep_Blue_(chess_computer)), [[2]](https://en.wikipedia.org/wiki/AlphaGo). Abstract board games typically include a low number of distinct game rules that yield complex emergent dynamics.
-* **Commercial board games** instead have been of little interest for the field of artificial intelligence, as well as have been of low interest for the field of video game programming. **Commercial board games** often have large amounts of rules written on game components, such as **Magic: The gathering** cards, that offer to the players complex sequences of actions, while the total amount of information a game state presents is usually low, because the user must be able to keep track of it in their minds. Instead, Video games often offer large amounts information, offered to the player whenever the information is needed, while single game sequences are simpler. For example, in many games you can press any button of any interface in any order. While there exists various digital implementations of board games, for example [board game arena](https://en.boardgamearena.com), in practice the larger video game programming ecosystem is not tuned for the development of digital board games.
+* **Commercial board games** instead have been of little interest for the field of artificial intelligence, as well as of low interest for the field of video game programming. **Commercial board games** often have large amounts of rules written on game components, such as **Magic: The Gathering** cards, that offer players complex sequences of actions, while the total amount of information a game state presents is usually low because the user must keep track of it mentally. In contrast, video games often provide large amounts of information only when needed, while single game sequences are simpler. For example, in many games you can press any button of any interface in any order. While there exist various digital implementations of board games—for example [Board Game Arena](https://en.boardgamearena.com)—in practice the broader video game programming ecosystem is not tuned for the development of digital board games.
 
 
 ---

--- a/docs/sphinx_doc/gym_tutorial.md
+++ b/docs/sphinx_doc/gym_tutorial.md
@@ -41,11 +41,11 @@ pip install numpy
 Let’s begin with a simple RLC program and build on top of it. Below is an implementation of the classic game *rock-paper-scissors*. Note that this example does not define the number of players or specify how the game state maps to the current player—these details are left implicit.
 
 ```rlc
-# rockpaperscizzor.rl
+# rockpaperscissor.rl
 enum Gesture:
     paper
     rock
-    scizzor
+    scissor
 
 @classes
 act play() -> Game:
@@ -79,10 +79,10 @@ Now that we have a Rulebook file, let's write a Python module to load it:
 
 from rlc import compile
 
-with compile(["./rockpaperscizzor.rl"]) as program:
+with compile(["./rockpaperscissor.rl"]) as program:
 ```
 
-This snippet compiles the `rockpaperscizzor.rl` file on the fly and returns a `Program` object—a wrapper that provides useful utilities like string conversions and formatted printing.
+This snippet compiles the `rockpaperscissor.rl` file on the fly and returns a `Program` object—a wrapper that provides useful utilities like string conversions and formatted printing.
 
 If you prefer not to use just-in-time (JIT) compilation—for example, if you don’t want to include the RLC compiler with your distribution—you can precompile the Rulebook program ahead of time and load it directly. *(TODO: Show how to do this.)*
 
@@ -92,7 +92,7 @@ However, our goal is not just to load the program and access its functions direc
 from rlc import compile
 from ml.env import SingleRLCEnvironment, exit_on_invalid_env
 
-with compile(["./rockpaperscizzor.rl"]) as program:
+with compile(["./rockpaperscissor.rl"]) as program:
     exit_on_invalid_env(program)
     env = SingleRLCEnvironment(program, solve_randomness=True)
 ```
@@ -144,7 +144,7 @@ A `SingleRLCEnvironment` includes:
 You can print the current game state as follows:
 
 ```python
-with compile(["./rockpaperscizzor.rl"]) as program:
+with compile(["./rockpaperscissor.rl"]) as program:
     exit_on_invalid_env(program)
     env = SingleRLCEnvironment(program, solve_randomness=True)
     env.print()
@@ -157,7 +157,7 @@ with compile(["./rockpaperscizzor.rl"]) as program:
 To obtain a tensor serialization of the state, use `get_state()`:
 
 ```python
-with compile(["./rockpaperscizzor.rl"]) as program:
+with compile(["./rockpaperscissor.rl"]) as program:
     exit_on_invalid_env(program)
     env = SingleRLCEnvironment(program, solve_randomness=True)
     print(env.get_state())
@@ -180,7 +180,7 @@ In this example, the serialized state is a one-hot representation:
 ## All Actions
 
 ```python
-with compile(["./rockpaperscizzor.rl"]) as program:
+with compile(["./rockpaperscissor.rl"]) as program:
     exit_on_invalid_env(program)
     env = SingleRLCEnvironment(program, solve_randomness=True)
     print("Here are the game actions:")
@@ -191,13 +191,13 @@ Running this program will print:
 
 ```
 Here are the game actions:
-['player1_move {g1: paper} ', 'player1_move {g1: rock} ', 'player1_move {g1: scizzor} ', 'player2_move {g2: paper} ', 'player2_move {g2: rock} ', 'player2_move {g2: scizzor} ']
+['player1_move {g1: paper} ', 'player1_move {g1: rock} ', 'player1_move {g1: scissor} ', 'player2_move {g2: paper} ', 'player2_move {g2: rock} ', 'player2_move {g2: scissor} ']
 ```
 
 ## Valid Actions
 
 ```python
-with compile(["./rockpaperscizzor.rl"]) as program:
+with compile(["./rockpaperscissor.rl"]) as program:
     exit_on_invalid_env(program)
     env = SingleRLCEnvironment(program, solve_randomness=True)
     print("Here is a NumPy array indicating which actions are currently valid:")
@@ -215,7 +215,7 @@ As expected, only the three actions available to player 0 are valid at the start
 
 To advance the state, there is a very simple function, `step` which accepts the index of the action to execute and returns the reward of that action, measured as the difference between the score before the action has been executed and the score after the action has been executed.
 ```
-with compile(["./rockpaperscizzor.rl"]) as program:
+with compile(["./rockpaperscissor.rl"]) as program:
     exit_on_invalid_env(program)
     env = SingleRLCEnvironment(program, solve_randomness=True)
     env.print()
@@ -224,7 +224,7 @@ with compile(["./rockpaperscizzor.rl"]) as program:
 ```
 ```
 {resume_index: 1, g1: paper, g2: paper}
-{resume_index: 2, g1: scizzor, g2: paper}
+{resume_index: 2, g1: scissor, g2: paper}
 ```
 
 ## Score
@@ -232,7 +232,7 @@ with compile(["./rockpaperscizzor.rl"]) as program:
 You can view the total score using:
 
 ```python
-with compile(["./rockpaperscizzor.rl"]) as program:
+with compile(["./rockpaperscissor.rl"]) as program:
     exit_on_invalid_env(program)
     env = SingleRLCEnvironment(program, solve_randomness=True)
     env.step(1)
@@ -244,14 +244,14 @@ with compile(["./rockpaperscizzor.rl"]) as program:
 This prints an array where the *i*-th element represents the total score of player *i*. In the example, player 0 plays rock, player 1 plays scissors, and player 0 receives a score of 1.0:
 
 ```
-{resume_index: -1, g1: rock, g2: scizzor}
+{resume_index: -1, g1: rock, g2: scissor}
 [1.0]
 ```
 
 You can also query the score obtained in the most recent step, instead of the cumulative score:
 
 ```python
-with compile(["./rockpaperscizzor.rl"]) as program:
+with compile(["./rockpaperscissor.rl"]) as program:
     exit_on_invalid_env(program)
     env = SingleRLCEnvironment(program, solve_randomness=True)
     print(env.last_score)
@@ -408,7 +408,7 @@ import machine_learning
 enum Gesture:
     paper
     rock
-    scizzor
+    scissor
 
 @classes
 act play() -> Game:

--- a/docs/sphinx_doc/language_tour.md
+++ b/docs/sphinx_doc/language_tour.md
@@ -108,7 +108,7 @@ Let’s say you wrote a simple rock-paper-scissors game. After player 1 selects 
 enum Gesture:
     rock
     paper
-    scizor
+    scissor
 
 act play() -> Game:
     act select(frm Gesture player1)
@@ -126,7 +126,7 @@ fun main() -> Int:
     copy.select(Gesture::rock)   # you lose
 
     copy = state
-    copy.select(Gesture::scizor) # you lose
+    copy.select(Gesture::scissor) # you lose
 
     copy = state
     copy.select(Gesture::paper)  # you win
@@ -146,7 +146,7 @@ Revisiting the rock-paper-scissors example, suppose you want to read which move 
 enum Gesture:
     rock
     paper
-    scizor
+    scissor
 
 act play() -> Game:
     act select(frm Gesture player1)

--- a/docs/sphinx_doc/project_rationale.md
+++ b/docs/sphinx_doc/project_rationale.md
@@ -1,7 +1,7 @@
 # Graphic engines and machine learning
 
 
-Machine learning is being unleashed onto the world with tremendous force. Year by year, machines solve more and more problems considered untractable and achieve super-human results.
+Machine learning is being unleashed onto the world with tremendous force. Year by year, machines solve more and more problems once considered intractable and achieve superhuman results.
 
 ![ML performances](./imgs/ml_progress.jpeg)
 
@@ -9,11 +9,11 @@ Reasoning and general game-playing still stand unsolved. We have no doubt algori
 Here is a picture taken from https://proceedings.mlr.press/v202/schwarzer23a/schwarzer23a.pdf.
 The X axis is the average competence at 26 atari games achieved by various algorithms, where 1 is the human-level ability, while the Y axis is how many hours of A100 GPUs took on average to get there.
 
-![Reinforcement learnign game progress](./imgs/rl_game_progress.webp)
+![Reinforcement learning game progress](./imgs/rl_game_progress.webp)
 
-Training a network to play an Atarii game takes (or will soon take) less than [32 A100 GPU hours](https://gpus.llm-utils.org/a100-gpu-cloud-availability-and-pricing/). As of 2023, an A100 GPU hour costs between 1 and 5 dollars.
+Training a network to play an Atari game takes (or will soon take) less than [32 A100 GPU hours](https://gpus.llm-utils.org/a100-gpu-cloud-availability-and-pricing/). As of 2023, an A100 GPU hour costs between 1 and 5 dollars.
 
-So, as of the moment of writing, a training run for an Atarii game costs in the ballpark of 30-150 dollars. If humanity can achieve a further 100x cost reduction, it will become possible for game designers train a super human playing agent agent that will help them to validate the quality of their designs for a very low price.
+So, as of the moment of writing, a training run for an Atari game costs in the ballpark of 30‑150 dollars. If humanity can achieve a further 100× cost reduction, it will become possible for game designers to train a superhuman playing agent that will help them validate the quality of their designs for a very low price.
 Thankfully, it seems that we will not have to wait that long to obtain that [cost reduction](https://www.redsharknews.com/nvidia-wants-to-increase-computing-power-by-a-factor-of-1-million).
 
 Still, 150 dollars seems a low enough cost that we would expect game companies to start adopting machine-learning techniques to at least validate their design before release.
@@ -41,22 +41,22 @@ The faster rules you will be able to get are those that
 * are implemented in a low-level language
 * and do not require running any piece of code except for the rules themselves. (That is: rules written independently from graphical engines, network protocols, or similar other mechanisms.)
 
-This requirement is essential since Moore's law for CPU cores is dead, and single CPU core speed is not increasing. Some games may be parallelizable and run on GPUs, but, in general, game rules are intrinsically imperative, and they must use traditional architectures. Since we cannot assume that in the future we will get faster hardware on which to run them,  we must design our solutions to extract every last drop of compute from single CPU cores.
+This requirement is essential since **Moore's law** for CPU cores is dead, and single‑core speed is no longer increasing. Some games may be parallelizable and run on GPUs, but, in general, game rules are intrinsically imperative and must use traditional architectures. Since we cannot assume that future hardware will be faster, we must design our solutions to extract every last drop of compute from a single CPU core.
 
-![Moore law for single-core CPUs image](./imgs/moore_law.jpg)
+![Moore's law for single-core CPUs image](./imgs/moore_law.jpg)
 
 Game rules, as implemented today, are designed with opposite intents than those just expressed, and in the next section, we will see why.
 
 ## Games
 
-To deliver 30 or 60 frames per second, games and engines must prioritize the rendering pipeline performances over anything else. While game rules often drive content to the scene, they are conceptually separated from the rendering pipeline algorithms and data structures. Game rules are akin to the business logic of a "buy" button on a website. The business logic tells you what the user wishes to do, but 99% of the complexity lies in forwarding that information to the various actors involved in delivering the product you bought to you and taking care of the payments. Game rules are thus the least critical aspect of game engine designs. It is acceptable for them to be slow or harder to understand as long as the rendering pipeline is the fastest it can be.
+To deliver 30 or 60 frames per second, games and engines must prioritize the rendering pipeline performance over everything else. While game rules often drive content to the scene, they are conceptually separated from the rendering pipeline algorithms and data structures. Game rules are akin to the business logic of a "buy" button on a website. The business logic tells you what the user wishes to do, but 99% of the complexity lies in forwarding that information to the various actors involved in delivering the product you bought to you and taking care of the payments. Game rules are thus the least critical aspect of game engine designs. It is acceptable for them to be slow or harder to understand as long as the rendering pipeline is the fastest it can be.
  This leads to a development loop where the engine and graphic programmers work on the internals of the engine, while designers hack together game mechanics through high-level features such as Godot scripting language, Unreal engine blueprints, Unity c# classes, and so on.
 
 ![Unity script image](./imgs/mono_behaviour.webp)
 
 Here is a Unity c# script, where a designer implements the game rules. Those rules will be expressed in terms of updates driven by the rendering pipeline main loop.  Already, the game logic has been intrinsically tied to the game engine and cannot be extracted.
 
-On top of that, if a piece of code written by a designer ends up being too slow, either because it was poorly written, the programming language itself was too slow, or the problem that programs solve is intrinsically slow, programmers will rewrite by placing performances at the forefront. Often this process will extract parts of the logic and will move then deeper down into the engine until parts of the game logic are no longer executable without executing the whole engine.
+On top of that, if a piece of code written by a designer ends up being too slow—either because it was poorly written, the programming language itself was too slow, or the problem that program solves is intrinsically slow—programmers will rewrite it by placing performance at the forefront. Often this process will extract parts of the logic and move them deeper into the engine until segments of the game logic are no longer executable without running the whole engine.
 
 Rules are therefore:
 * slow
@@ -70,13 +70,13 @@ All of these issues impede machine learning adoption in the game programming spa
 From the previous sections we have seen that the requirements imposed by machine learning and game programming are very different, let us recap them here. Game rules must be
 * **inspectable data structures**: the state of the game is of interest to the machine learning engine, so it must be inspectable, serializable, and copiable.
 * **have enumerable actions**: the machine learning component will interact with the simulation by deciding which actions must be executed, so they must be all known.
-* **implemented in a low-level language**: so that single-core CPU performances are not left on the table.
+* **implemented in a low-level language**: so that single-core CPU performance is not left on the table.
 * **interoperable with C**: so that the language can interact with machine learning tools and game programming tools, as well as allowing programmers to write optimized C code if they wish.
 * **engine independent**: so that samples can be generated without running the engine
 * **easily writable**: so that game designers can still write and refactor it. We should assume that in the future automatic code editing through LLM and similar techniques will be very common. It is important to create a language that is as easy as possible to edit for machines as well.
 
 To meet those requirements we have designed RL with the following characteristics:
-* **LLVM-based compiled language**: LLVM is a compiler framework used by many compilers (such as rustic, clang, and so on). Reinventing the wheel would lead to worse performances.
+* **LLVM-based compiled language**: LLVM is a compiler framework used by many compilers (such as Rust, Clang, and so on). Reinventing the wheel would lead to worse performance.
 * **Statically typed language**: All possible analyses on the code, such as discovering all the possible actions as functions that can advance the game state, should be performed during compilation. Thus, we should design the language so the compiler can get as much insight as possible into the program.
 * **Same ABI as C**: By laying our structs in memory the same way C does and by following the same calling conventions we obtain trivial compatibility with C programs and, transitively, with every application compatible with C (for example, with Python due to ctypes).
 * **Imperative language**: Game rules are conceptualized by designers as procedures players must follow. Since we are trying to produce a simple language, we should strive to keep the difference between how one thinks of games and how one implements them. Thus, RL must be an imperative language.

--- a/docs/sphinx_doc/stdlib/collections/vector.md
+++ b/docs/sphinx_doc/stdlib/collections/vector.md
@@ -4,10 +4,10 @@
 
 
 ```text
- A memory contiguous datastructure similar to cpp vector.
- A vector is a list of elements. Just like cpp vector,
- the contents may be reallocated when added or deleated,
- so references elements are invalidated if the 
+ A contiguous data structure similar to a C++ vector.
+ A vector is a list of elements. Just like a C++ vector,
+ the contents may be reallocated when elements are added or deleted,
+ so references to elements are invalidated if the 
  vector is modified.
 
 ```
@@ -172,11 +172,11 @@
 - **Function**: `append(T value) `
 
 ```text
- append `value` to the end
- of the vector, but only if
- doing so would not exceed
- max vector maximal size
-
+ A contiguous data structure similar to a C++ vector.
+ A vector is a list of elements. Just like a C++ vector,
+ the contents may be reallocated when elements are added or deleted,
+ so references to elements are invalidated if the
+ vector is modified.
 ```
 
 - **Function**: `empty()  -> Bool`

--- a/docs/sphinx_doc/tutorial.md
+++ b/docs/sphinx_doc/tutorial.md
@@ -53,10 +53,10 @@ rlc example.rl -o executable
 
 Now that you've ensured your system works, download the `black jack` example from [here](https://github.com/rl-language/rlc/tool/rlc/test/examples/black_jack.rl) and save it in a file in the directory we created at the start of this example.
 
-Black jack is example that shows how to handle games with randomness and imperfect information. Indeed the actions taken by the real user are usually just one or two, while most of the game is spent by the `randomness player` shuffling the deck, which is a fake player that performs actions at random.
+Blackjack is an example that shows how to handle games with randomness and imperfect information. Indeed, the actions taken by the real user are usually just one or two, while most of the game is spent by the `randomness player` shuffling the deck—a fake player that performs actions at random.
 
 
-After you have copied it, let us make sure we can run generate a random game.
+After you have copied it, let us make sure we can generate a random game.
 
 ```
 rlc-random black_jack.rl
@@ -98,7 +98,7 @@ You should see a graph that looks similar to the following:
 
 The x-axis is the number of actions played. In the case of our game, it means the number of `hits` and `stand` executed, the y-axis is instead the average score obtained. As expected the average score is increasing, that is: it is learning to play.
 
-Of course, the machine will never achieve a average score of one, because there is no guarantee you can always hit 21 points, not even if you knew the order of the cards in the deck. Furthermore, the size of the neural network has been defaulted to a reasonable size, but there is no guarantee that the problem is solvable given the default size.
+Of course, the machine will never achieve an average score of one, because there is no guarantee you can always hit 21 points—even if you knew the order of the cards in the deck. Furthermore, the size of the neural network has been defaulted to a reasonable value, but there is no guarantee that the problem is solvable given the default size.
 
 Still, with very few commands and a very simple `.rl` file, we managed to have a reasonably configured network up and learning.
 


### PR DESCRIPTION
## Summary
- fix typos and clean wording in documentation under `docs/sphinx_doc`
- correct spelling of "scissor" examples and "Blackjack" tutorial text
- clarify descriptions in project rationale and board games docs
- improve vector collection overview

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68436dd5bfdc833384c70d24d16931bf